### PR TITLE
Caching

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,8 +6,8 @@ class PagesController < UsersBaseController
   def index
     render locals: {
       max_records: MAX_RECORDS,
-      comments: Comment.newest_first.includes_for_listing.first(MAX_RECORDS),
-      commits: Commit.for_index,
+      comments: Comment.newest_first.includes_for_listing.limit(MAX_RECORDS).pluck(:cached_data),
+      commits: Commit.for_index.pluck(:cached_data),
     }
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,6 @@
 class Comment < ActiveRecord::Base
   serialize :payload, Hash
+  serialize :cached_data, Hash
 
   belongs_to :author
   belongs_to :resolved_by_author, class: Author
@@ -8,8 +9,10 @@ class Comment < ActiveRecord::Base
     foreign_key: :commit_sha,
     primary_key: :sha
 
-  scope :newest_first, -> { order("id DESC") }
+  scope :newest_first, -> { order("comments.id DESC") }
   scope :includes_for_listing, -> { includes({ :commit => :author }, :author) }
+
+  before_save -> { self.cached_data = as_json }
 
   def self.create_or_update_from_payload(payload)
     CreateOrUpdateFromPayload.call(payload)

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -4,18 +4,21 @@ class Commit < ActiveRecord::Base
   MESSAGE_SUMMARY_LENGTH = 50
 
   serialize :payload, Hash
+  serialize :cached_data, Hash
 
   belongs_to :author
   belongs_to :reviewed_by_author, class: Author
   belongs_to :review_started_by_author, class: Author
 
-  scope :newest_first, -> { order("id DESC") }
+  scope :newest_first, -> { order("commits.id DESC") }
   scope :includes_for_listing, -> { includes(:author, :reviewed_by_author) }
-  scope :unreviewed, -> { where("reviewed_at IS NULL") }
+  scope :unreviewed, -> { where("commits.reviewed_at IS NULL") }
 
   scope :for_index, -> {
     newest_first.includes_for_listing.limit(PagesController::MAX_RECORDS)
   }
+
+  before_save -> { self.cached_data = as_json }
 
   def self.create_or_update_from_payload(commit_payload, push_payload)
     CreateOrUpdateFromPayload.call(commit_payload, push_payload)

--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -1,3 +1,5 @@
+# NOTE: Cached data is used for display, so serialization changes will require
+#       a migration to apply to all records. E.g: Comment.find_each(&:save)
 class CommentSerializer < ApplicationSerializer
   attributes :id,
     :github_id,

--- a/app/serializers/commit_serializer.rb
+++ b/app/serializers/commit_serializer.rb
@@ -1,3 +1,5 @@
+# NOTE: Cached data is used for display, so serialization changes will require
+#       a migration to apply to all records. E.g: Commit.find_each(&:save)
 class CommitSerializer < ApplicationSerializer
   attributes :id,
     :author_name,

--- a/db/migrate/20151124200211_add_cached_data_to_commits.rb
+++ b/db/migrate/20151124200211_add_cached_data_to_commits.rb
@@ -1,0 +1,9 @@
+class AddCachedDataToCommits < ActiveRecord::Migration
+  def change
+    add_column :commits, :cached_data, :text
+
+    Commit.find_each do |commit|
+      commit.update_column(:cached_data, commit.as_json)
+    end
+  end
+end

--- a/db/migrate/20151124200943_add_cached_data_to_comments.rb
+++ b/db/migrate/20151124200943_add_cached_data_to_comments.rb
@@ -1,0 +1,9 @@
+class AddCachedDataToComments < ActiveRecord::Migration
+  def change
+    add_column :comments, :cached_data, :text
+
+    Comment.find_each do |comment|
+      comment.update_column(:cached_data, comment.as_json)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,12 +11,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140701184309) do
+ActiveRecord::Schema.define(version: 20151124200943) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "authors", force: true do |t|
+  create_table "authors", force: :cascade do |t|
     t.string   "name"
     t.string   "email"
     t.string   "username"
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(version: 20140701184309) do
     t.datetime "updated_at"
   end
 
-  create_table "comments", force: true do |t|
+  create_table "comments", force: :cascade do |t|
     t.text     "payload",               null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 20140701184309) do
     t.integer  "author_id",             null: false
     t.datetime "resolved_at"
     t.integer  "resolved_by_author_id"
+    t.text     "cached_data"
   end
 
   add_index "comments", ["author_id"], name: "index_comments_on_author_id", using: :btree
@@ -40,7 +41,7 @@ ActiveRecord::Schema.define(version: 20140701184309) do
   add_index "comments", ["github_id"], name: "index_comments_on_github_id", unique: true, using: :btree
   add_index "comments", ["resolved_by_author_id"], name: "index_comments_on_resolved_by_author_id", using: :btree
 
-  create_table "commits", force: true do |t|
+  create_table "commits", force: :cascade do |t|
     t.string   "sha",                         null: false
     t.text     "payload",                     null: false
     t.datetime "created_at"
@@ -50,6 +51,7 @@ ActiveRecord::Schema.define(version: 20140701184309) do
     t.integer  "reviewed_by_author_id"
     t.datetime "review_started_at"
     t.integer  "review_started_by_author_id"
+    t.text     "cached_data"
   end
 
   add_index "commits", ["author_id"], name: "index_commits_on_author_id", using: :btree


### PR DESCRIPTION
Caching comments and commits for faster load times. Caches the "as_json" hash on each row as it changes.

Has some drawbacks (you have to consider it when making schema or serialization changes) so not a given that this is a good idea.
